### PR TITLE
Feature/multip mine status

### DIFF
--- a/discmine_status.py
+++ b/discmine_status.py
@@ -45,7 +45,7 @@ CONNECTIVES = [
     "instead",
     "rather",
 ]
-CDICT = {CONNECTIVES[i]: i for i in range(len(connectives))}
+CDICT = {CONNECTIVES[i]: i for i in range(len(CONNECTIVES))}
 
 
 def get_connective_counts(filename):
@@ -69,7 +69,7 @@ def summarize(in_dir):
             mod_times.append(os.path.getmtime(doc_name))
 
     with Pool(4) as status_pool:
-        connective_counts = np.stack(status_pool.map(get_connective_counts, docs))
+        connective_counts = np.stack(status_pool.map(get_connective_counts, docs)).sum(axis=0)
     
     for i, c in enumerate(CONNECTIVES):
         print(f"{c}{' '*(25-len(c))}{connective_counts[i]}")

--- a/discmine_status.py
+++ b/discmine_status.py
@@ -57,7 +57,7 @@ def get_connective_counts(filename):
 
     return con_counts
 
-def summarize(in_dir):
+def summarize(in_dir, num_procs=4):
     docs = []
     samples = {}
     mod_times = []
@@ -68,7 +68,7 @@ def summarize(in_dir):
             docs.append(doc_name)
             mod_times.append(os.path.getmtime(doc_name))
 
-    with Pool(4) as status_pool:
+    with Pool(num_procs) as status_pool:
         connective_counts = np.stack(status_pool.map(get_connective_counts, docs)).sum(axis=0)
     
     for i, c in enumerate(CONNECTIVES):

--- a/discmine_status.py
+++ b/discmine_status.py
@@ -2,35 +2,84 @@ import os
 import time
 import json
 import subprocess
+from multiprocessing import Pool
 
+import numpy as np
 import fire
 
+CONNECTIVES = [
+    "afterward(s)",
+    "after that",
+    "eventually",
+    "in turn",
+    "later",
+    "next",
+    "thereafter",
+    "before that",
+    "earlier",
+    "previously",
+    "in the meantime",
+    "meanwhile",
+    "simultaneously",
+    "accordingly",
+    "as a result",
+    "consequently",
+    "therefore",
+    "thus",
+    "additionally",
+    "also",
+    "besides",
+    "further(more)",
+    "in addition",
+    "likewise",
+    "moreover",
+    "similarly",
+    "by/in comparison",
+    "by/in contrast",
+    "conversely",
+    "nevertheless",
+    "on the other hand",
+    "for example",
+    "for instance",
+    "in particular",
+    "instead",
+    "rather",
+]
+CDICT = {CONNECTIVES[i]: i for i in range(len(connectives))}
+
+
+def get_connective_counts(filename):
+    con_counts = np.zeros(len(CONNECTIVES))
+
+    doc = json.load(open(filename, "r"))
+    for sample in doc:
+        con_counts[CDICT[sample["connective"]]] += 1
+
+    return con_counts
 
 def summarize(in_dir):
+    docs = []
     samples = {}
     mod_times = []
+
     for root, dirs, files in os.walk(in_dir):
         for name in files:
-            mod_times.append(os.path.getmtime(os.path.join(root, name)))
-            doc = json.load(open(os.path.join(root, name), "r"))
+            doc_name = os.path.join(root, name)
+            docs.append(doc_name)
+            mod_times.append(os.path.getmtime(doc_name))
 
-            for sample in doc:
-                if sample["connective"] in samples:
-                    samples[sample["connective"]] += 1
-                else:
-                    samples[sample["connective"]] = 1
+    with Pool(4) as status_pool:
+        connective_counts = np.stack(status_pool.map(get_connective_counts, docs))
+    
+    for i, c in enumerate(CONNECTIVES):
+        print(f"{c}{' '*(25-len(c))}{connective_counts[i]}")
+    print(f"Total samples mined: {connective_counts.sum()}")
 
     disk_usage = subprocess.check_output(['du','-sh', in_dir]).split()[0].decode('utf-8')
-
-    samples = {k: v for k, v in sorted(samples.items(), key=lambda item: item[1])}
-    for k, v in samples.items():
-        print(f"{k}{' '*(25-len(k))}{v}")
-
-    print(f"Total samples mined: {sum([x for x in samples.values()])}")
-
-    first_write = time.ctime(min(mod_times))
-    print(f"\nMine started: {first_write}")
     print(f"Disk space used: {disk_usage}")
+
+    # first_write = time.ctime(min(mod_times))
+    # print(f"\nMine started: {first_write}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Perform mining status check with multiple processes. The number of processes default to 4. This script no longer logs the start time of the mining job.